### PR TITLE
Fix typo in sotsuron-presen.html

### DIFF
--- a/sotsuron-presen.html
+++ b/sotsuron-presen.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div class="timer">
-  <div id="abst">卒研究最終セミナー</div>
+  <div id="abst">卒業研究最終セミナー</div>
   <div id="day"></div>
   <div id="time"></div>
   <div hidden id="dst_time">January 30, 2024 09:00:00</div>


### PR DESCRIPTION
タイポ直しました．

修正前
<img width="415" alt="image" src="https://github.com/lab-ish/fun-countdown/assets/75069543/0d3ec52a-8dd0-4865-9ac1-7097f24a5da0">

修正後
![image](https://github.com/lab-ish/fun-countdown/assets/75069543/bb209536-d7d0-41bb-9271-478b35e255fe)
